### PR TITLE
Add participant counter to study sessions

### DIFF
--- a/app/templates/study_sessions.html
+++ b/app/templates/study_sessions.html
@@ -46,6 +46,11 @@
         {{ session.mode }}
       </p>
 
+      <p class="session-text">
+        <i class="bi bi-person-check me-2 text-primary"></i>
+        {{ session.participants|length }} / {{ session.max_spots }} participants joined
+      </p>
+
       <!-- USER ALREADY JOINED -->
       {% if current_user in session.participants %}
 


### PR DESCRIPTION
Implemented a participant counter for study sessions.

Changes:
- Added participant count display to session cards
- Shows current joined users out of the maximum session capacity
- Improved visibility of session availability for users