### PR TITLE
Show creator on study session cards

### DIFF
--- a/app/templates/study_sessions.html
+++ b/app/templates/study_sessions.html
@@ -27,6 +27,11 @@
       </div>
 
       <p class="session-text">
+        <i class="bi bi-person-circle me-2 text-primary"></i>
+        Created by {{ session.creator.name }}
+      </p>
+
+      <p class="session-text">
         <i class="bi bi-calendar me-2 text-primary"></i>
         {{ session.date }}
       </p>


### PR DESCRIPTION
Added session creator display to study session cards.

Changes made:

* Added creator name visibility for each study session
* Improved session information clarity for users
* Added creator icon styling to match existing UI
* Helps users identify who created each session before joining
