### PR TITLE
Add leave session functionality

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -91,6 +91,19 @@ def join_session(session_id):
         db.session.commit()
         flash('Successfully joined the session!', 'success')
     return redirect(url_for('main.sessions'))
+@main.route('/sessions/<int:session_id>/leave', methods=['POST'])
+@login_required
+def leave_session(session_id):
+    session = StudySession.query.get_or_404(session_id)
+
+    if current_user not in session.participants:
+        flash('You are not currently joined in this session.', 'warning')
+    else:
+        session.participants.remove(current_user)
+        db.session.commit()
+        flash('You have left the session.', 'success')
+
+    return redirect(url_for('main.sessions'))
 @main.route('/sessions/<int:session_id>/edit', methods=['GET', 'POST'])
 @login_required
 def edit_session(session_id):

--- a/app/templates/study_sessions.html
+++ b/app/templates/study_sessions.html
@@ -49,11 +49,27 @@
       <!-- USER ALREADY JOINED -->
       {% if current_user in session.participants %}
 
-      <div class="d-flex gap-2 mt-3">
+      <div class="d-flex gap-2 mt-3 flex-wrap">
 
         <button class="btn btn-secondary px-4" disabled>
           Already Joined
         </button>
+
+        <form
+          action="{{ url_for('main.leave_session', session_id=session.id) }}"
+          method="POST">
+
+          <button
+            type="submit"
+            class="btn btn-outline-danger px-4"
+            onclick="return confirm('Are you sure you want to leave this session?');">
+
+            <i class="bi bi-box-arrow-right me-1"></i>
+            Leave
+
+          </button>
+
+        </form>
 
         {% if session.creator_id == current_user.id %}
 


### PR DESCRIPTION
Added leave session functionality for study sessions.

Changes made:

* Added backend leave_session route
* Users can now leave joined study sessions
* Added leave session button to session cards
* Added confirmation popup before leaving a session
* Session participant list updates automatically after leaving
* Improved overall session management usability
