### PR TITLE
i have fixed the matching password issue

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -27,7 +27,13 @@ def signup():
     if request.method == 'POST':
         name = request.form.get('name')
         email = request.form.get('email')
+        
         password = request.form.get('password')
+        confirm = request.form.get('confirm')
+        if password != confirm:
+            flash('Passwords do not match.', 'danger')
+            return redirect(url_for('auth.signup'))
+
         if User.query.filter_by(email=email).first():
             flash('Email already registered.', 'danger')
             return redirect(url_for('auth.signup'))


### PR DESCRIPTION
previously when creating an account you are prompted to re-enter your password for security but this doesn't do anything.
previously when saving your password it used the first one you entered as your password.
now when creating an account it prompts you to re-enter a password for security and now this works properly. if these passwords do not match then you get an error message and are told to do it again. 
<img width="1291" height="903" alt="Screenshot 2026-05-12 at 14 11 16" src="https://github.com/user-attachments/assets/ebda625d-3ca8-4b01-bf38-9520bc624ca7" />
